### PR TITLE
(fix) Add top-level `.gitmodules` file

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "mupen64plus-rsp-paraLLEl/lightning/gnulib"]
+	path = mupen64plus-rsp-paraLLEl/lightning/gnulib
+	url = git://git.sv.gnu.org/gnulib.git


### PR DESCRIPTION
This commit is avoiding the following error:

```
❯ git submodule sync
git submodule update --init --recursive
git lfs pull
git submodule foreach 'git lfs pull'

fatal: No url found for submodule path
'mupen64plus-rsp-paraLLEl/lightning/gnulib' in .gitmodules

fatal: No url found for submodule path
'mupen64plus-rsp-paraLLEl/lightning/gnulib' in .gitmodules
```

The upstream project has a whole other project copied/moved under `mupen64plus-rsp-paraLLEl/lightning` with its own `.gitmodules` file, but git needs it to be defined top-level only.